### PR TITLE
Replaced "Patterns" with "Include" and "Exclude"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/__pycache__/**
 regolith-filters.code-workspace
+.idea

--- a/debug_say_function_name/README.md
+++ b/debug_say_function_name/README.md
@@ -21,7 +21,8 @@ project to actually enable it:
                     {
                         "filter": "debug_say_function_name",
                         "settings": {
-                            "patterns": ["**/*.mcfunction"],
+                            "include": ["**/*.mcfunction"],
+                            "exclude": [],
                             "random_colors": true,
                             "prefix": ""
                         }
@@ -33,9 +34,13 @@ All settings are optional. The example above shows the default values. Not
 providing any settings will result in the filter working in the same way as
 with the settings above.
 
-The "patterns" is a list of glob patterns to match against the subpaths of
+The "include" is a list of glob patterns to match against the subpaths of
 `BP/functions` to determine if the filter should be applied. By default it
 matches all mcfunction files (`**/*.mcfunction`).
+
+The "exclude" is a list of glob patterns to match against the subpaths of
+`BP/functions` to determine if the filter should be applied. By default 
+this matches no files.
 
 The "random_colors" setting determines if the function names should be printed
 in random colors. By default it's set to `true`. The colors are picked

--- a/debug_say_function_name/main.py
+++ b/debug_say_function_name/main.py
@@ -33,10 +33,14 @@ def generate_tellraw_command(
 
 if __name__ == '__main__':
     config = json.loads(sys.argv[1])
-    if 'patterns' in config:
-        patterns = config['patterns']
+    if 'include' in config:
+        include = config['include']
     else:
-        patterns = ["**/*.mcfunction"]
+        include = ["**/*.mcfunction"]
+    if 'exclude' in config:
+        exclude = config['exclude']
+    else:
+        exclude = []
     if 'random_colors' in config:
         random_colors = config['random_colors']
     else:
@@ -47,9 +51,14 @@ if __name__ == '__main__':
         prefix = ""
 
     paths_set = set()
-    for pattern in patterns:
-        for path in FUNCTIONS_PATH.glob(pattern):
+    excluded_paths_list = []
+    for excluded_paths in exclude:
+        for path in FUNCTIONS_PATH.glob(excluded_paths):
             if path.is_file():
+                excluded_paths_list.append(path)
+    for included_files in include:
+        for path in FUNCTIONS_PATH.glob(included_files):
+            if path.is_file() and path not in excluded_paths_list:
                 paths_set.add(path)
     for path in paths_set:
         with path.open('r', encoding="utf8") as f:

--- a/debug_say_function_name/test/config.json
+++ b/debug_say_function_name/test/config.json
@@ -1,6 +1,6 @@
 {
-	"name": "Debug Say Function Name Example",
 	"author": "Nusiq",
+	"name": "Debug Say Function Name Example",
 	"packs": {
 		"behaviorPack": "./packs/BP",
 		"resourcePack": "./packs/RP"
@@ -13,6 +13,7 @@
 				"script": "../main.py"
 			},
 			"filter_tester": {
+				"url": "github.com/Bedrock-OSS/regolith-filters",
 				"version": "1.0.0"
 			}
 		},
@@ -26,7 +27,10 @@
 					{
 						"filter": "debug_say_function_name",
 						"settings": {
-							"patterns": [
+							"exclude": [
+								"**/lobby.mcfunction"
+							],
+							"include": [
 								"**/*.mcfunction"
 							],
 							"prefix": "[MyCustomPrefix] ",

--- a/debug_say_function_name/test/data/filter_tester/BP/functions/warp/lobby.mcfunction
+++ b/debug_say_function_name/test/data/filter_tester/BP/functions/warp/lobby.mcfunction
@@ -1,2 +1,1 @@
-tellraw @a {"rawtext":[{"text":"[MyCustomPrefix] "},{"selector":"@s"},{"text":": "},{"text":"§2warp/lobby"}]}
 tp @s 1 2 3 90 0


### PR DESCRIPTION
Replaced the `patterns `argument with `include` and `exclude`. 

`Include ` is just a rename of `patterns`.
`Exclude` is a list of files the filter will exclude. It uses the same syntax as include, but is empty by default. 