### PR TITLE
Pack Anything - Use usual ZIP compression method

### DIFF
--- a/pack_anything/main.py
+++ b/pack_anything/main.py
@@ -37,7 +37,7 @@ def main():
         (resolver_input_path(k), Path(v))
         for k, v in config['pathmap'].items()
     ]
-    with zipfile.ZipFile(output, 'w') as zf:
+    with zipfile.ZipFile(output, 'w', zipfile.ZIP_DEFLATED) as zf:
         for path_on_disk, path_in_zip in pathmap:
             if path_on_disk.is_file():
                 zf.write(path_on_disk, path_in_zip)


### PR DESCRIPTION
This change lets the Pack Anything filter to compress the resulting zip file in the usual way.
The zip file was uncompressed before, resulting in our team not using the filter in production and compiling the release manually instead.