### PR TITLE
pack_anything: produce spec-conformant, deterministically-ordered ZIP archives

### DIFF
--- a/pack_anything/README.md
+++ b/pack_anything/README.md
@@ -22,7 +22,8 @@ For example configuration below could be used to create Mctemplate file:
             // This configuration assumes that you keep the world files in your
             // project in "worlds/release-world" directory.
             "PROJECT:worlds/release-world": "."
-        }
+        },
+        "allow_backslash_paths": false
     }
 }
 ```
@@ -41,3 +42,11 @@ Adding this setting to the configuration would create an mctemplate file named l
 
 ## pathmap
 A dictionary that maps the paths in the project to the paths in the output ZIP file. By default, the paths start in Regolith working directory, which means you have access to `RP`, `BP` and `data` folders. If you put a `PROJECT:` prefix in the path, it will start in the Regolith project directory.
+
+## allow_backslash_paths
+> [!WARNING]
+> This is `false` by default. You almost certainly don't want to enable it in anything related to Minecraft.
+
+When `false` (default): paths from the pathmap setting are normalized to use `/`. If a file or directory discovered during compression contains a literal `\` in its name, the filter will error.
+
+When `true`: the filter will allow creating ZIP entries containing `\` in names. This won't work on Windows (which always treats `\` as a path separator). Archives created with such names on other platforms also won't extract correctly on Windows.

--- a/pack_anything/main.py
+++ b/pack_anything/main.py
@@ -41,17 +41,26 @@ def main():
     with zipfile.ZipFile(output, 'w', zipfile.ZIP_DEFLATED) as zf:
         for path_on_disk, path_in_zip in pathmap:
             if path_on_disk.is_file():
-                zf.write(path_on_disk, path_in_zip)
+                zf.write(path_on_disk, path_in_zip.as_posix())
                 continue
-            if Path(path_in_zip) != Path('.'):
+            if path_in_zip != Path('.'):
                 zf.mkdir(path_in_zip.as_posix())
-            for file in path_on_disk.rglob('*'):
-                out_path = (
-                    path_in_zip / file.relative_to(path_on_disk)).as_posix()
-                if file.is_file():
+            # os.walk with topdown=True guarantees that each directory is
+            # visited before its contents, so directory entries are always
+            # written to the archive before any of their child files.
+            for dirpath, dirnames, filenames in os.walk(path_on_disk):
+                dirnames.sort()
+                filenames.sort()
+                rel_dir = Path(dirpath).relative_to(path_on_disk)
+                for dirname in dirnames:
+                    out_path = (
+                        path_in_zip / rel_dir / dirname).as_posix()
+                    zf.mkdir(out_path)
+                for filename in filenames:
+                    file = Path(dirpath) / filename
+                    out_path = (
+                        path_in_zip / rel_dir / filename).as_posix()
                     zf.write(file, out_path)
-                    continue
-                zf.mkdir(out_path)
 
 if __name__ == '__main__':
     main()

--- a/pack_anything/main.py
+++ b/pack_anything/main.py
@@ -4,8 +4,21 @@ import sys
 import json
 import os
 import subprocess
+from typing import Any, Callable
 
 PROJECT_PATH = Path(os.environ['ROOT_DIR'])
+
+class BackslashPathError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+def print_red(text: str):
+    for t in text.split('\n'):
+        print("\033[91m {}\033[00m".format(t))
 
 def resolver_input_path(path: str):
     if path.startswith('PROJECT:'):
@@ -24,43 +37,86 @@ def get_git_tag():
         return 'unknown'
 
 def main():
-    config = json.loads(sys.argv[1])
+    config: dict[str, Any] = json.loads(sys.argv[1])
     output_str = config['output']
     if output_str.startswith('`') and output_str.endswith('`'):
         output_str = output_str[1:-1]
         output_str = eval(output_str, {'git_describe': get_git_tag()})
+
+
+    # When the backslash paths are disabled (default), and we're not on Windows,
+    # we silently replce the path segments that contain backslahses with
+    # forward slashes. On Windows such paths in 'Path' object are impossible,
+    # so we don't do anything.
+    needs_backslash_cleanup = (
+        not config.get('allow_backslash_paths', False) and
+        sys.platform != "win32"
+    )
+
+    backslahs_cleanup: Callable[[Path], Path] = lambda p: p
+    if needs_backslash_cleanup:
+        backslahs_cleanup = lambda p: Path(p.as_posix().replace('\\', '/'))
 
     output: Path = Path(PROJECT_PATH) / output_str
     output.parent.mkdir(parents=True, exist_ok=True)
 
     # [path_on_disk, path_in_zip]
     pathmap: list[tuple[Path, Path]] = [
-        (resolver_input_path(k), Path(v))
+        (
+            backslahs_cleanup(resolver_input_path(k)),
+            backslahs_cleanup(Path(v)),
+        )
         for k, v in config['pathmap'].items()
     ]
-    with zipfile.ZipFile(output, 'w', zipfile.ZIP_DEFLATED) as zf:
-        for path_on_disk, path_in_zip in pathmap:
-            if path_on_disk.is_file():
-                zf.write(path_on_disk, path_in_zip.as_posix())
-                continue
-            if path_in_zip != Path('.'):
-                zf.mkdir(path_in_zip.as_posix())
-            # os.walk with topdown=True guarantees that each directory is
-            # visited before its contents, so directory entries are always
-            # written to the archive before any of their child files.
-            for dirpath, dirnames, filenames in os.walk(path_on_disk):
-                dirnames.sort()
-                filenames.sort()
-                rel_dir = Path(dirpath).relative_to(path_on_disk)
-                for dirname in dirnames:
-                    out_path = (
-                        path_in_zip / rel_dir / dirname).as_posix()
-                    zf.mkdir(out_path)
-                for filename in filenames:
-                    file = Path(dirpath) / filename
-                    out_path = (
-                        path_in_zip / rel_dir / filename).as_posix()
-                    zf.write(file, out_path)
+    try:
+        with zipfile.ZipFile(output, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for path_on_disk, path_in_zip in pathmap:
+                if path_on_disk.is_file():
+                    zf.write(path_on_disk, path_in_zip.as_posix())
+                    continue
+                if path_in_zip != Path('.'):
+                    zf.mkdir(path_in_zip.as_posix())
+                # os.walk with topdown=True guarantees that each directory is
+                # visited before its contents, so directory entries are always
+                # written to the archive before any of their child files.
+                for dirpath, dirnames, filenames in os.walk(path_on_disk):
+                    dirnames.sort()
+                    filenames.sort()
+                    rel_dir = Path(dirpath).relative_to(path_on_disk)
+                    for dirname in dirnames:
+                        out_path = (
+                            path_in_zip / rel_dir / dirname).as_posix()
+                        if needs_backslash_cleanup and out_path.find('\\') != -1:
+                            raise BackslashPathError(
+                                'Error: Backslash detected in one of the ZIP paths.\n'
+                                f'- ZIP Path: {out_path}'
+                            )
+                        zf.mkdir(out_path)
+                    for filename in filenames:
+                        file = Path(dirpath) / filename
+                        out_path = (
+                            path_in_zip / rel_dir / filename).as_posix()
+                        if needs_backslash_cleanup and out_path.find('\\') != -1:
+                            raise BackslashPathError(
+                                'Error: Backslash detected in one of the ZIP paths.\n'
+                                f'- Source Path: {file.as_posix()}\n'
+                                f'- ZIP Path: {out_path}'
+                            )
+                        zf.write(file, out_path)
+    except BackslashPathError as e:
+        print_red(
+            f'{e.message}\n\n'
+            'This is almost certainly not what you want, since file names '
+            'that include backslashes are not supported on Windows. Please, '
+            'make sure that the project is generated correctly, or enable '
+            'the "allow_backslash_paths" option in the config file.'
+        )
+        output.unlink(missing_ok=True)
+        exit(1)
+    except Exception as e:
+        output.unlink(missing_ok=True)
+        raise Exception("Unexpected error while creating the ZIP file.") from e
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixes two issues with the ZIPs produced by `pack_anything`:

### 1. Non-conformant path separators (Windows)
When `pack_anything` ran on Windows, file entries were written with a `Path` object as `arcname`. `ZipFile.write` calls `os.fspath()` on it, which on Windows produces `dir\file.txt`. The ZIP spec (APPNOTE.TXT §4.4.17.1) requires forward slashes, and strict extractors (`unzip` on Linux, Java's `ZipInputStream`, browsers, etc.) treat `dir\file.txt` as a single literal filename rather than a nested path.

**Fix:** always pass `path_in_zip.as_posix()` to `zf.write`.

### 2. Child files appearing before their parent directory entry
`Path.rglob('*')` yields entries in filesystem-traversal order, mixing files and directories. As a result, files inside a subdirectory could be written into the archive **before** the subdirectory's own directory entry. While not strictly forbidden by the spec, several downstream tools assume parents precede children and were breaking on these archives.

**Fix:** switched to `os.walk(path_on_disk)` (top-down), which guarantees each directory is visited before its contents. Within each directory we emit the subdirectory entries first, then the files. `dirnames` and `filenames` are sorted at each level for deterministic, alphabetical archive ordering across platforms/filesystems.

No new imports are required (`os` was already in use).